### PR TITLE
Add NextBot support

### DIFF
--- a/lua/autorun/!!inf_detours_sh.lua
+++ b/lua/autorun/!!inf_detours_sh.lua
@@ -11,6 +11,8 @@ local EntityMT = FindMetaTable("Entity")
 local VehicleMT = FindMetaTable("Vehicle")
 local PhysObjMT = FindMetaTable("PhysObj")
 local PlayerMT = FindMetaTable("Player")
+local NextBotMT = FindMetaTable("NextBot")
+local CLuaLocomotionMT = FindMetaTable("CLuaLocomotion")
 local CTakeDamageInfoMT = FindMetaTable("CTakeDamageInfo")
 
 /*********** Entity Metatable *************/
@@ -111,6 +113,37 @@ end
 PlayerMT.InfMap_GetShootPos = PlayerMT.InfMap_GetShootPos or PlayerMT.GetShootPos
 function PlayerMT:GetShootPos()
 	return InfMap.unlocalize_vector(self:InfMap_GetShootPos(), self.CHUNK_OFFSET)
+end
+
+/**************** NextBot Metatable *****************/
+
+NextBotMT.InfMap_GetRangeSquaredTo = NextBotMT.InfMap_GetRangeSquaredTo or NextBotMT.GetRangeSquaredTo
+function NextBotMT:GetRangeSquaredTo(to)
+	if isentity(to) then to = to:GetPos() end
+	return self:GetPos():DistToSqr(to)
+end
+
+NextBotMT.InfMap_GetRangeTo = NextBotMT.InfMap_GetRangeTo or NextBotMT.GetRangeTo
+function NextBotMT:GetRangeTo(to)
+	return math.sqrt(self:GetRangeSquaredTo(to))
+end
+
+/*************** CLuaLocomotion Metatable *****************/
+
+CLuaLocomotionMT.InfMap_Approach = CLuaLocomotionMT.InfMap_Approach or CLuaLocomotionMT.Approach
+function CLuaLocomotionMT:Approach(goal, goalweight)
+	local nb = self:GetNextBot()
+	local dir = (goal - nb:GetPos()):GetNormalized()
+	local pos = InfMap.localize_vector(nb:GetPos() + dir)
+	return CLuaLocomotionMT.InfMap_Approach(self, pos, goalweight)
+end
+
+CLuaLocomotionMT.InfMap_FaceTowards = CLuaLocomotionMT.InfMap_FaceTowards or CLuaLocomotionMT.FaceTowards
+function CLuaLocomotionMT:FaceTowards(goal)
+	local nb = self:GetNextBot()
+	local dir = (goal - nb:GetPos()):GetNormalized()
+	local pos = InfMap.localize_vector(nb:GetPos() + dir)
+	return CLuaLocomotionMT.InfMap_FaceTowards(self, pos)
 end
 
 /**************** Other Functions ********************/

--- a/lua/autorun/server/inf_chunks_sv.lua
+++ b/lua/autorun/server/inf_chunks_sv.lua
@@ -32,7 +32,7 @@ local function unfucked_SetPos(ent, pos)
 	pos[3] = math.Clamp(pos[3], -source_bounds, source_bounds)
 
 	local phys = ent:GetPhysicsObject()
-	if phys:IsValid() and !class_filter[ent:GetClass()] and !ent:IsNPC() then 
+	if phys:IsValid() and !class_filter[ent:GetClass()] and !(ent:IsNPC() or ent:IsNextBot()) then
 		phys:SetVelocity(ent:GetVelocity())	// ????????????????????
 		phys:InfMap_SetPos(pos, true)
 	else


### PR DESCRIPTION
This change allows NextBots to move across chunks without breaking.
It also redefines the GetRangeTo and GetRangeSquaredTo functions to make use of the rerouted GetPos.

This doesn't fix the issues that happen when NextBots (or NPCs) are moved across chunks using the physics gun.