### PR TITLE
Sound detouring / entity detection

### DIFF
--- a/lua/infmap/client/cl_inf_detours.lua
+++ b/lua/infmap/client/cl_inf_detours.lua
@@ -37,6 +37,17 @@ hook.Add("EntityFireBullets", "infmap_detour", function(ent, data)
 	end
 end)
 
+//recieve networked sounds
+net.Receive( "inf_entsound", function( len, ply )
+	local soundTable = net.ReadTable()
+	local ent = soundTable.Entity
+	if LocalPlayer().CHUNK_OFFSET != ent.CHUNK_OFFSET then //this does not properly support moving chunks with continuous sounds playing e.g. thrusters! (or explosions?)
+		soundTable.Volume = 0 //set volume to zero if not in chunk, otherwise continuous sounds will not update to players outside chunk
+	end
+
+	ent:EmitSound(soundTable.OriginalSoundName,soundTable.SoundLevel,soundTable.Pitch,soundTable.Volume,soundTable.Channel,soundTable.Flags,soundTable.DSP)
+end )
+
 /*********** Client Entity Metatable *************/
 
 EntityMT.InfMap_SetRenderBounds = EntityMT.InfMap_SetRenderBounds or EntityMT.SetRenderBounds

--- a/lua/infmap/client/cl_inf_detours.lua
+++ b/lua/infmap/client/cl_inf_detours.lua
@@ -44,8 +44,9 @@ net.Receive( "inf_entsound", function( len, ply )
 	if LocalPlayer().CHUNK_OFFSET != ent.CHUNK_OFFSET then //this does not properly support moving chunks with continuous sounds playing e.g. thrusters! (or explosions?)
 		soundTable.Volume = 0 //set volume to zero if not in chunk, otherwise continuous sounds will not update to players outside chunk
 	end
-
-	ent:EmitSound(soundTable.OriginalSoundName,soundTable.SoundLevel,soundTable.Pitch,soundTable.Volume,soundTable.Channel,soundTable.Flags,soundTable.DSP)
+	if ent:IsValid() then //wac fix, not an entity?
+		ent:EmitSound(soundTable.OriginalSoundName,soundTable.SoundLevel,soundTable.Pitch,soundTable.Volume,soundTable.Channel,soundTable.Flags,soundTable.DSP)
+	end
 end )
 
 /*********** Client Entity Metatable *************/

--- a/lua/infmap/client/cl_inf_detours.lua
+++ b/lua/infmap/client/cl_inf_detours.lua
@@ -41,7 +41,7 @@ end)
 net.Receive( "inf_entsound", function( len, ply )
 	local soundTable = net.ReadTable()
 	local ent = soundTable.Entity
-	if LocalPlayer().CHUNK_OFFSET != ent.CHUNK_OFFSET then //this does not properly support moving chunks with continuous sounds playing e.g. thrusters! (or explosions?)
+	if LocalPlayer():GetPos():Distance(ent:GetPos()) > InfMap.chunk_size then //this does not properly support moving chunks with continuous sounds playing e.g. thrusters! (or explosions?)
 		soundTable.Volume = 0 //set volume to zero if not in chunk, otherwise continuous sounds will not update to players outside chunk
 	end
 	if ent:IsValid() then //wac fix, not an entity?

--- a/lua/infmap/server/sv_inf_detours.lua
+++ b/lua/infmap/server/sv_inf_detours.lua
@@ -310,7 +310,7 @@ util.AddNetworkString( "inf_entsound" )
 hook.Add( "EntityEmitSound", "inf_ent_sound", function( t )
 	if t.Entity:IsWorld() then //emitting sounds from world is stupid, lets change to entity
 		local dist = 2^14
-		local ent, vec, co
+		local ent, vec
 		for k, v in pairs( ents.GetAll() ) do
 			vec = InfMap.localize_vector(v:GetPos()) //get true pos correction
 			if vec:DistToSqr(t.Pos) < dist and v:GetClass() != "infmap_terrain_collider" then //get closest entity to emitted sound, not terrain collider!

--- a/lua/infmap/server/sv_inf_detours.lua
+++ b/lua/infmap/server/sv_inf_detours.lua
@@ -311,10 +311,10 @@ hook.Add( "EntityEmitSound", "inf_ent_sound", function( t )
 	if t.Entity:IsWorld() then //emitting sounds from world is stupid, lets change to entity
 		local dist = 2^14
 		local ent, vec, co
-		for k, v in pairs( ents.GetAll() ) do //findinsphere more efficient, but don't know entity size
+		for k, v in pairs( ents.GetAll() ) do
 			vec = InfMap.localize_vector(v:GetPos()) //get true pos correction
-			if vec:DistToSqr(t.Pos) < dist and v:GetClass() != "infmap_terrain_collider" then //get closest entity to emitted sound, not terrain collider
-				dist = v:GetPos():DistToSqr(t.Pos)
+			if vec:DistToSqr(t.Pos) < dist and v:GetClass() != "infmap_terrain_collider" then //get closest entity to emitted sound, not terrain collider!
+				dist = vec:DistToSqr(t.Pos)
 				ent = v
 			end
 		end

--- a/lua/infmap/server/sv_inf_detours.lua
+++ b/lua/infmap/server/sv_inf_detours.lua
@@ -304,6 +304,27 @@ hook.Add("Initialize", "infmap_wire_detour", function()
 	end
 end)
 
+//detour sounds for client processing
+util.AddNetworkString( "inf_entsound" )
+
+hook.Add( "EntityEmitSound", "inf_ent_sound", function( t )
+	if t.Entity:IsWorld() then //emitting sounds from world is stupid, lets change to entity
+		local dist = 2^14
+		local ent
+		for k, v in pairs( ents.GetAll() ) do
+			if v:GetPos():DistToSqr(t.Pos) < dist then //get closest entity to emitted sound
+				dist = v:GetPos():DistToSqr(t.Pos) 
+				ent = v 
+			end
+		end
+		t.Entity = ent
+	end
+	net.Start("inf_entsound")
+	net.WriteTable(t) //send to client for local playback
+	net.Broadcast()
+	return false
+end)
+
 // when entities are spawned, reset them
 hook.Add("PlayerSpawn", "infinite_plyreset", function(ply, trans)
 	print("Resetting " .. ply:Nick() .." to chunk 0,0,0")

--- a/lua/infmap/server/sv_inf_detours.lua
+++ b/lua/infmap/server/sv_inf_detours.lua
@@ -311,7 +311,7 @@ hook.Add( "EntityEmitSound", "inf_ent_sound", function( t )
 	if t.Entity:IsWorld() then //emitting sounds from world is stupid, lets change to entity
 		local dist = 2^14
 		local ent, vec, co
-		for k, v in pairs( ents.GetAll() ) do
+		for k, v in pairs( ents.GetAll() ) do //findinsphere more efficient, but don't know entity size
 			vec = InfMap.localize_vector(v:GetPos()) //get true pos correction
 			if vec:DistToSqr(t.Pos) < dist and v:GetClass() != "infmap_terrain_collider" then //get closest entity to emitted sound, not terrain collider
 				dist = v:GetPos():DistToSqr(t.Pos)

--- a/lua/infmap/server/sv_inf_detours.lua
+++ b/lua/infmap/server/sv_inf_detours.lua
@@ -310,14 +310,15 @@ util.AddNetworkString( "inf_entsound" )
 hook.Add( "EntityEmitSound", "inf_ent_sound", function( t )
 	if t.Entity:IsWorld() then //emitting sounds from world is stupid, lets change to entity
 		local dist = 2^14
-		local ent
+		local ent, vec, co
 		for k, v in pairs( ents.GetAll() ) do
-			if v:GetPos():DistToSqr(t.Pos) < dist then //get closest entity to emitted sound
-				dist = v:GetPos():DistToSqr(t.Pos) 
-				ent = v 
+			vec = InfMap.localize_vector(v:GetPos()) //get true pos correction
+			if vec:DistToSqr(t.Pos) < dist and v:GetClass() != "infmap_terrain_collider" then //get closest entity to emitted sound, not terrain collider
+				dist = v:GetPos():DistToSqr(t.Pos)
+				ent = v
 			end
 		end
-		t.Entity = ent
+		if ent then t.Entity = ent end //is valid ent?
 	end
 	net.Start("inf_entsound")
 	net.WriteTable(t) //send to client for local playback


### PR DESCRIPTION
This is an attempt to detour sounds to the client for local playback, to stop sounds from looping.

Playback from entity sounds is fine, but impacts default to world annoyingly, so a search function is used to try and work out what entity the sound came from. 

The main feature missing is support for continuous sounds when crossing chunk borders, e.g. thrusters, but this feels like somewhat of an edge case as if they update at all then the handler will catch and fix the sound.