### PR TITLE
Allow custom infmaps to use custom phys material for collider

### DIFF
--- a/lua/entities/infmap_terrain_collider.lua
+++ b/lua/entities/infmap_terrain_collider.lua
@@ -228,6 +228,7 @@ function ENT:Initialize()
     //self:AddFlags(FL_DONTTOUCH)
     local phys = self:GetPhysicsObject()
     if IsValid(phys) then
+        phys:SetMaterial(InfMap.physprop or "dirt")
         phys:EnableMotion(false)
         phys:SetMass(50000)  // max weight should help a bit with the physics solver
         phys:AddGameFlag(FVPHYSICS_CONSTRAINT_STATIC)


### PR DESCRIPTION
Haven't seen any "sinking" problems with this fix, seems to work fine. I defined `InfMap.physprop` in my custom sh_terrain_collision.lua.