### PR TITLE
Find Function Detours

### DIFF
--- a/lua/infmap/client/cl_inf_chunks.lua
+++ b/lua/infmap/client/cl_inf_chunks.lua
@@ -112,6 +112,10 @@ hook.Add("PostDrawOpaqueRenderables", "infinite_player_render", function()
 	
 end)
 
+hook.Add("EntityRemoved","infinite_cleanup_cl",function()
+	InfMap.cleanup_track(ent)
+end)
+
 // server tells clients when a prop has entered another chunk
 // detour rendering of entities in other chunks
 local empty_function = function() end

--- a/lua/infmap/client/cl_inf_chunks.lua
+++ b/lua/infmap/client/cl_inf_chunks.lua
@@ -117,6 +117,7 @@ end)
 local empty_function = function() end
 function InfMap.prop_update_chunk(ent, chunk)
 	local prev_chunk = ent.CHUNK_OFFSET
+	InfMap.update_track(ent,chunk)
 	ent.CHUNK_OFFSET = chunk
 
 	hook.Run("PropUpdateChunk", ent, chunk, prev_chunk)

--- a/lua/infmap/client/cl_inf_detours.lua
+++ b/lua/infmap/client/cl_inf_detours.lua
@@ -6,6 +6,9 @@ local PlayerMT = FindMetaTable("Player")
 local NextBotMT = FindMetaTable("NextBot")
 local CTakeDamageInfoMT = FindMetaTable("CTakeDamageInfo")
 
+// To eventually be used, when clientside detours are made for find funcs (starfall/GLua)
+//local MaxFindDistCvar = CreateClientConVar("infmap_max_find_distance_cl","65536",true,false,"Maximum distance from the first position a find function is allowed to check, but clientside (for SF)",1)
+
 EntityMT.InfMap_GetPos = EntityMT.InfMap_GetPos or EntityMT.GetPos
 function EntityMT:GetPos()
 	if !self.CHUNK_OFFSET or !LocalPlayer().CHUNK_OFFSET then return self:InfMap_GetPos(pos) end

--- a/lua/infmap/server/sv_inf_chunks.lua
+++ b/lua/infmap/server/sv_inf_chunks.lua
@@ -286,6 +286,9 @@ hook.Add("OnEntityCreated", "infinite_propreset", function(ent)
 	end)
 end)
 
+hook.Add("EntityRemoved","infinite_cleanup",function(ent)
+	InfMap.cleanup_track(ent)
+end)
 
 // disable picking up weapons/items in other chunks
 local function can_pickup(ply, ent)

--- a/lua/infmap/sh_inf_functions.lua
+++ b/lua/infmap/sh_inf_functions.lua
@@ -197,6 +197,7 @@ end
 InfMap.ent_list = {}
 
 function InfMap.cleanup_track(ent)
+	if not IsValid(ent) then return end
 	if ent.CHUNK_OFFSET then
 		local oldcoord = InfMap.ezcoord(ent.CHUNK_OFFSET)
 		if not InfMap.ent_list[oldcoord] then return end // some how we made it all the way here

--- a/lua/infmap/sh_inf_functions.lua
+++ b/lua/infmap/sh_inf_functions.lua
@@ -31,7 +31,7 @@ function InfMap.localize_vector(pos, size)
 	return pos, chunk_offset
 end
 
-function InfMap.unlocalize_vector(pos, chunk) 
+function InfMap.unlocalize_vector(pos, chunk)
 	return (chunk or Vector()) * InfMap.chunk_size * 2 + pos
 end
 
@@ -155,7 +155,7 @@ local function constrained_invalid_filter(ent)
 	return InfMap.filter_entities(ent) or (!ent:IsSolid() and ent:GetNoDraw()) or ent:GetParent():IsValid() or phys_filter or (ent:IsWeapon() and ent:GetOwner():IsValid())
 end
 
-function InfMap.constrained_status(ent) 
+function InfMap.constrained_status(ent)
 	if ent.CONSTRAINED_MAIN != nil then
 		return ent.CONSTRAINED_MAIN
 	end
@@ -188,4 +188,32 @@ end
 function InfMap.reset_constrained_data(ent)
 	ent.CONSTRAINED_DATA = nil 
 	ent.CONSTRAINED_MAIN = nil
+end
+
+function InfMap.ezcoord(chunk)
+	return chunk.x .. "," .. chunk.y .. "," .. chunk.z
+end
+
+InfMap.ent_list = {}
+
+function InfMap.cleanup_track(ent)
+	if ent.CHUNK_OFFSET then
+		local oldcoord = InfMap.ezcoord(ent.CHUNK_OFFSET)
+		if not InfMap.ent_list[oldcoord] then return end // some how we made it all the way here
+		InfMap.ent_list[oldcoord][ent:EntIndex()] = nil // scrub old entry
+		if table.IsEmpty(InfMap.ent_list[oldcoord]) then InfMap.ent_list[oldcoord] = nil end // lil cleanup action here
+	end
+end
+
+function InfMap.update_track(ent,chunk)
+	if not IsValid(ent) then return end
+	if ent.CHUNK_OFFSET then InfMap.cleanup_track(ent) end
+
+	local curchunk = InfMap.ezcoord(chunk)
+
+	if not InfMap.ent_list[curchunk] then InfMap.ent_list[curchunk] = {} end
+
+	InfMap.ent_list[curchunk][ent:EntIndex()] = true
+
+	PrintTable(InfMap.ent_list)
 end

--- a/lua/infmap/sh_inf_networking.lua
+++ b/lua/infmap/sh_inf_networking.lua
@@ -1,11 +1,12 @@
 if SERVER then
 	function InfMap.prop_update_chunk(ent, chunk)
 		print(ent, "passed in chunk", chunk)
-		
+
 		local prev_chunk = ent.CHUNK_OFFSET
+		InfMap.update_track(ent,chunk)
 		ent.CHUNK_OFFSET = chunk
 		ent:SetCustomCollisionCheck(true)	// required for ShouldCollide hook
-		
+
 		hook.Run("PropUpdateChunk", ent, chunk, prev_chunk)
 
 		// make sure to teleport things in chairs too


### PR DESCRIPTION
Added detours for:
FindInBox
FindInSphere
FindInCone (but technically correct)

Also added:
InfMap.ezcoord (turns a chunk coordinate into a string for easy use with entlist table)
InfMap.cleanup_track (cleans old entry in chunk table)
InfMap.update_track (calls above, and then actually writes the new entry)
FindInChunk (returns all of the entities in a chunk)
FindInChunkPostCoord (to be used if you have, for example, indexed using ezcoord

Removed:
Other FindInSphere override

In doing this, there is also a cheap entity tracking system that updates whenever an entity crosses a chunk boundary; old entries are deleted, and if a chunk's table ends up being empty it is removed from the global list
Obviously this only works if an entity actually gets affected by chunk updates

In theory this is cheaper in some cases than the vanilla find functions by using chunks as a way to divide and organize things, HOWEVER these functions do not have limits and can still lag the crap out of the game, so further limitations may be required

Some effort was made to make sure clientside is able to call it, just as you can in vanilla, but salt should still be ingested when it comes to trusting clientside to catch updates